### PR TITLE
Zabbix 6.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,3 @@
-![](https://i.imgur.com/N6GqEC1.png)
-
 # Zabbix: EdgeMAX Template (SNMPv2)
 
 This template allows you to quickly get up and running with monitoring of Ubiquiti's EdgeRouter line of devices. It allows for auto-discovering of network interfaces and automatically applies appropriate triggers for the discovered network interfaces.
@@ -14,14 +12,18 @@ This template allows you to quickly get up and running with monitoring of Ubiqui
    1. Set *SNMP community* to the same value as your macro or the other way around.
 
 ## 🏷️ Features
+- ✔️ Monitoring of memory utiliziation of system
+- ✔️ Monitoring of CPU load
 - ✔️ Auto discovering of network interfaces
+- ✔️ Monitoring address per network interface
 - ✔️ Monitoring traffic in/out per network interface
 - ✔️ Monitoring up/down status per network interface
-- ✔️ Monitoring of discarded and error packets per network interface
-- ✔️ Monitoring of memory utiliziation of system
-- 🔶 Linked with **Template Module Generic SNMPv2**
+- ⚠️ Monitoring link speed per network interface (see issues)
+- 🔶 Linked with **Generic by SNMP**
 
 ## Supported models
+This should work with all EdgeRouters. Partial compatibility with Edgeswitches.
+
 Updated as of 2020-04-30.
 - **EdgeRouter**
   - ER-X
@@ -30,6 +32,7 @@ Updated as of 2020-04-30.
 
 ## Issues
 - [Wrong ethernet link status/speed via SNMP](https://community.ui.com/questions/Wrong-ethernet-link-status-speed-via-SNMP/6e50940c-3cc1-4242-9881-5c03e7892ebf)
+  (some of this issue is due to how ubiquiti is treating "standard" SNMP OIDs. The link status should be fixe but the speed is still troublesome)
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,8 @@ This template allows you to quickly get up and running with monitoring of Ubiqui
 - 🔶 Linked with **Generic by SNMP**
 
 ## 📣 Triggers
-Items witch checks are enable by default. Those with Xs are disabled by default. You can customise your triggers to your needs per network interfaces
+Items witch checks are enable by default. Those with Xs are disabled by default. You can customise your triggers to your needs per network interfaces.
+
 From linked template:
 - ✅ High ping loss 
 - ✅ High response time

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,12 @@
 # Zabbix: EdgeMAX Template (SNMPv2)
 
-This template allows you to quickly get up and running with monitoring of Ubiquiti's EdgeRouter line of devices. It allows for auto-discovering of network interfaces and automatically applies appropriate triggers for the discovered network interfaces.
+This template allows you to quickly get up and running with monitoring of Ubiquiti's EdgeRouter line of devices. It allows for auto-discovering of network interfaces and automatically applies some triggers for the discovered network interfaces. Many more triggers are included but disabled by default.
 
 ## ⚙️ Installation
 
 1. Select a branch according to your Zabbix version and download the xml.
 2. Import *zbx_edgemax_template.xml* to Zabbix (Configuration -> Templates -> Import)
-3. Add the template *Template EdgeMAX SNMPv2* to your host and configure 
+3. Add the template *EdgeMAX SNMPv2* to your host and configure 
    1. Add *{$SNMP_COMMUNITY}* to your host's macros and configure it. (default is usually public)
 4. Enable the *SNMP* agent on your EdgeMAX device.
    1. Set *SNMP community* to the same value as your macro or the other way around.
@@ -21,14 +21,34 @@ This template allows you to quickly get up and running with monitoring of Ubiqui
 - ⚠️ Monitoring link speed per network interface (see issues)
 - 🔶 Linked with **Generic by SNMP**
 
+## 📣 Triggers
+Items witch checks are enable by default. Those with Xs are disabled by default. You can customise your triggers to your needs per network interfaces
+From linked template:
+- ✅ High ping loss 
+- ✅ High response time
+- ✅ Host has been restarted
+- ✅ No SNMP data
+- ✅ System name has changed
+- ✅ Unavailable by ping
+
+From this template:
+- ✅ High memory usage
+- ✅ High system load
+- ✅ Interface address has changed
+- ✅ Interface status has changed
+- ❎ Interface is not up (1)
+
 ## Supported models
 This should work with all EdgeRouters. Partial compatibility with Edgeswitches.
 
-Updated as of 2020-04-30.
+Updated as of 2023-10-01.
 - **EdgeRouter**
   - ER-X
   - ER-5 ( + poe)
   - ER-6 ( + poe)
+
+- **EdgeSwitch**
+  - ES-10XP
 
 ## Issues
 - [Wrong ethernet link status/speed via SNMP](https://community.ui.com/questions/Wrong-ethernet-link-status-speed-via-SNMP/6e50940c-3cc1-4242-9881-5c03e7892ebf)

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ Updated as of 2023-10-01.
 
 ## Issues
 - [Wrong ethernet link status/speed via SNMP](https://community.ui.com/questions/Wrong-ethernet-link-status-speed-via-SNMP/6e50940c-3cc1-4242-9881-5c03e7892ebf)
-  (some of this issue is due to how ubiquiti is treating "standard" SNMP OIDs. The link status should be fixe but the speed is still troublesome)
+  (some of this issue is due to how ubiquiti is treating "standard" SNMP OIDs. The link status should be fixed but the speed is still troublesome)
 
 
 ## License

--- a/zabbix6.0/zbx_edgemax_template.xml
+++ b/zabbix6.0/zbx_edgemax_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>6.0</version>
-    <date>2023-09-27T12:57:24Z</date>
+    <date>2023-09-27T13:25:29Z</date>
     <groups>
         <group>
             <uuid>36bff6c29af64692839d077febfc7079</uuid>
@@ -349,7 +349,7 @@
                                     <uuid>b3ee11aac54940819c9615d7ced39e33</uuid>
                                     <expression>last(/EdgeMAX SNMPv2/net.if.ip[ipAddrEntry.{#SNMPINDEX}],#1)&lt;&gt;last(/EdgeMAX SNMPv2/net.if.ip[ipAddrEntry.{#SNMPINDEX}],#2) and length(last(/EdgeMAX SNMPv2/net.if.ip[ipAddrEntry.{#SNMPINDEX}]))&gt;0</expression>
                                     <recovery_mode>NONE</recovery_mode>
-                                    <name>EdgeMAX: Interface address has changed</name>
+                                    <name>EdgeMAX: Interface {#IFNAME} address has changed</name>
                                     <event_name>EdgeMAX: Interface {#IFNAME} address on {HOST.HOST} has changed from {FUNCTION.VALUE2} to {FUNCTION.VALUE3}.</event_name>
                                     <opdata>Interface {#IFNAME} address is  {ITEM.LASTVALUE1}</opdata>
                                     <priority>INFO</priority>
@@ -449,7 +449,7 @@
                                     <expression>last(/EdgeMAX SNMPv2/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)&lt;&gt;last(/EdgeMAX SNMPv2/net.if.status[ifOperStatus.{#SNMPINDEX}],#2) and last(/EdgeMAX SNMPv2/net.if.status[ifOperStatus.{#SNMPINDEX}],#2)=1</expression>
                                     <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
                                     <recovery_expression>last(/EdgeMAX SNMPv2/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)=1</recovery_expression>
-                                    <name>EdgeMAX: Interface status has changed</name>
+                                    <name>EdgeMAX: Interface {#IFNAME} status has changed</name>
                                     <event_name>EdgeMAX: Interface {#IFNAME} on {HOST.HOST} status has changed from up (1).</event_name>
                                     <opdata>Interface {#IFNAME} is currently {ITEM.VALUE1}</opdata>
                                     <priority>AVERAGE</priority>

--- a/zabbix6.0/zbx_edgemax_template.xml
+++ b/zabbix6.0/zbx_edgemax_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>6.0</version>
-    <date>2023-09-26T13:33:58Z</date>
+    <date>2023-09-27T12:57:24Z</date>
     <groups>
         <group>
             <uuid>36bff6c29af64692839d077febfc7079</uuid>
@@ -25,57 +25,29 @@
             </groups>
             <items>
                 <item>
-                    <uuid>268fe8c15d99415dafd32fec95ebb9f0</uuid>
-                    <name>Load average last 5 minute</name>
-                    <type>SNMP_AGENT</type>
-                    <snmp_oid>1.3.6.1.4.1.2021.10.1.3.2</snmp_oid>
-                    <key>Load5Minute</key>
-                    <history>1d</history>
-                    <value_type>FLOAT</value_type>
-                    <description>5 minute Load</description>
-                    <tags>
-                        <tag>
-                            <tag>Application</tag>
-                            <value>System Info</value>
-                        </tag>
-                    </tags>
-                </item>
-                <item>
-                    <uuid>effdbb0807574ffa80fa9ee2deaf9685</uuid>
-                    <name>Load average last 15 minutes</name>
-                    <type>SNMP_AGENT</type>
-                    <snmp_oid>1.3.6.1.4.1.2021.10.1.3.3</snmp_oid>
-                    <key>Load15Minute</key>
-                    <history>1d</history>
-                    <value_type>FLOAT</value_type>
-                    <description>15 minute Load</description>
-                    <tags>
-                        <tag>
-                            <tag>Application</tag>
-                            <value>System Info</value>
-                        </tag>
-                    </tags>
-                </item>
-                <item>
                     <uuid>62c2558cc3b24573bb425869bd680ae0</uuid>
-                    <name>Load average last 1 minute</name>
+                    <name>EdgeMAX: Load average last 1 minute</name>
                     <type>SNMP_AGENT</type>
                     <snmp_oid>1.3.6.1.4.1.2021.10.1.3.1</snmp_oid>
-                    <key>LoadMinute</key>
+                    <key>Load1Minute</key>
                     <history>1d</history>
                     <value_type>FLOAT</value_type>
                     <tags>
                         <tag>
-                            <tag>Application</tag>
-                            <value>System Info</value>
+                            <tag>component</tag>
+                            <value>load</value>
+                        </tag>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
                         </tag>
                     </tags>
                     <triggers>
                         <trigger>
                             <uuid>229564ad1b274f4887812a3af0ffafc6</uuid>
-                            <expression>last(/EdgeMAX SNMPv2/LoadMinute)&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}</expression>
+                            <expression>last(/EdgeMAX SNMPv2/Load1Minute)&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}</expression>
                             <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                            <recovery_expression>last(/EdgeMAX SNMPv2/LoadMinute)&lt;{$LOAD_AVG_PER_CPU.MAX.WARN}</recovery_expression>
+                            <recovery_expression>last(/EdgeMAX SNMPv2/Load1Minute)&lt;{$LOAD_AVG_PER_CPU.MAX.WARN}</recovery_expression>
                             <name>EdgeMAX: Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 1m)</name>
                             <opdata>Load averages(1m): {ITEM.LASTVALUE1}</opdata>
                             <priority>AVERAGE</priority>
@@ -90,8 +62,48 @@
                     </triggers>
                 </item>
                 <item>
+                    <uuid>268fe8c15d99415dafd32fec95ebb9f0</uuid>
+                    <name>EdgeMAX: Load average last 5 minute</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.10.1.3.2</snmp_oid>
+                    <key>Load5Minute</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <description>5 minute Load</description>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>load</value>
+                        </tag>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>effdbb0807574ffa80fa9ee2deaf9685</uuid>
+                    <name>EdgeMAX: Load average last 15 minutes</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.10.1.3.3</snmp_oid>
+                    <key>Load15Minute</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <description>15 minute Load</description>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>load</value>
+                        </tag>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
                     <uuid>55d17189b0894e5bb5aed103ca860527</uuid>
-                    <name>Total amount of available memory</name>
+                    <name>EdgeMAX: Total amount of available memory</name>
                     <type>SNMP_AGENT</type>
                     <snmp_oid>1.3.6.1.4.1.2021.4.6.0</snmp_oid>
                     <key>MemAvailable</key>
@@ -108,14 +120,18 @@
                     </preprocessing>
                     <tags>
                         <tag>
-                            <tag>Application</tag>
-                            <value>Memory</value>
+                            <tag>component</tag>
+                            <value>memory</value>
+                        </tag>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
                         </tag>
                     </tags>
                 </item>
                 <item>
                     <uuid>8a61a3d93e194ee7a44420db20b37de6</uuid>
-                    <name>Total amount of buffers</name>
+                    <name>EdgeMAX: Total amount of buffers</name>
                     <type>SNMP_AGENT</type>
                     <snmp_oid>1.3.6.1.4.1.2021.4.14.0</snmp_oid>
                     <key>MemBuffers</key>
@@ -132,14 +148,18 @@
                     </preprocessing>
                     <tags>
                         <tag>
-                            <tag>Application</tag>
-                            <value>Memory</value>
+                            <tag>component</tag>
+                            <value>memory</value>
+                        </tag>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
                         </tag>
                     </tags>
                 </item>
                 <item>
                     <uuid>c858f465d2bb4651a23bcfa86596c371</uuid>
-                    <name>Total amount of cached</name>
+                    <name>EdgeMAX: Total amount of cached</name>
                     <type>SNMP_AGENT</type>
                     <snmp_oid>1.3.6.1.4.1.2021.4.15.0</snmp_oid>
                     <key>MemCached</key>
@@ -156,14 +176,18 @@
                     </preprocessing>
                     <tags>
                         <tag>
-                            <tag>Application</tag>
-                            <value>Memory</value>
+                            <tag>component</tag>
+                            <value>memory</value>
+                        </tag>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
                         </tag>
                     </tags>
                 </item>
                 <item>
                     <uuid>ba758bc30b3a47f69f834e6815589a2d</uuid>
-                    <name>Total amount of memory</name>
+                    <name>EdgeMAX: Total amount of memory</name>
                     <type>SNMP_AGENT</type>
                     <snmp_oid>1.3.6.1.4.1.2021.4.5.0</snmp_oid>
                     <key>MemTotal</key>
@@ -180,30 +204,38 @@
                     </preprocessing>
                     <tags>
                         <tag>
-                            <tag>Application</tag>
-                            <value>Memory</value>
+                            <tag>component</tag>
+                            <value>memory</value>
+                        </tag>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
                         </tag>
                     </tags>
                 </item>
                 <item>
                     <uuid>b3f2f99e384a492d8d838c007a9f1081</uuid>
-                    <name>Used memory</name>
+                    <name>EdgeMAX: Used memory</name>
                     <type>CALCULATED</type>
                     <key>MemUsed</key>
                     <history>7d</history>
                     <trends>0</trends>
-                    <units>B</units>
+                    <units>b</units>
                     <params>last(//MemTotal)-last(//MemAvailable)</params>
                     <tags>
                         <tag>
-                            <tag>Application</tag>
-                            <value>Memory</value>
+                            <tag>component</tag>
+                            <value>memory</value>
+                        </tag>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
                         </tag>
                     </tags>
                 </item>
                 <item>
                     <uuid>74e161402bc1440e8d30a413c7a0968e</uuid>
-                    <name>Memory utizilation</name>
+                    <name>EdgeMAX: Memory utizilation</name>
                     <type>CALCULATED</type>
                     <key>MemUtil</key>
                     <history>7d</history>
@@ -221,8 +253,12 @@
                     </preprocessing>
                     <tags>
                         <tag>
-                            <tag>Application</tag>
-                            <value>Memory</value>
+                            <tag>component</tag>
+                            <value>memory</value>
+                        </tag>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
                         </tag>
                     </tags>
                     <triggers>
@@ -280,9 +316,48 @@
                             <tags>
                                 <tag>
                                     <tag>Application</tag>
-                                    <value>Network</value>
+                                    <value>Interface Speed</value>
+                                </tag>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
                                 </tag>
                             </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>c01af9e30682460fa97177bc067f7327</uuid>
+                            <name>Interface {#IFNAME} : Address</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.4.20.1.1[index, 1.3.6.1.2.1.4.20.1.2, {#SNMPINDEX}]</snmp_oid>
+                            <key>net.if.ip[ipAddrEntry.{#SNMPINDEX}]</key>
+                            <delay>10m</delay>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <tags>
+                                <tag>
+                                    <tag>Application</tag>
+                                    <value>interface ip address</value>
+                                </tag>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
+                                </tag>
+                            </tags>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>b3ee11aac54940819c9615d7ced39e33</uuid>
+                                    <expression>last(/EdgeMAX SNMPv2/net.if.ip[ipAddrEntry.{#SNMPINDEX}],#1)&lt;&gt;last(/EdgeMAX SNMPv2/net.if.ip[ipAddrEntry.{#SNMPINDEX}],#2) and length(last(/EdgeMAX SNMPv2/net.if.ip[ipAddrEntry.{#SNMPINDEX}]))&gt;0</expression>
+                                    <recovery_mode>NONE</recovery_mode>
+                                    <name>EdgeMAX: Interface address has changed</name>
+                                    <event_name>EdgeMAX: Interface {#IFNAME} address on {HOST.HOST} has changed from {FUNCTION.VALUE2} to {FUNCTION.VALUE3}.</event_name>
+                                    <opdata>Interface {#IFNAME} address is  {ITEM.LASTVALUE1}</opdata>
+                                    <priority>INFO</priority>
+                                    <description>The interface address has changed. Acknowledge to close the problem manually.</description>
+                                    <type>MULTIPLE</type>
+                                    <manual_close>YES</manual_close>
+                                </trigger_prototype>
+                            </trigger_prototypes>
                         </item_prototype>
                         <item_prototype>
                             <uuid>b067d0d9f6cf4212a35849f2d6d6309f</uuid>
@@ -310,7 +385,11 @@
                             <tags>
                                 <tag>
                                     <tag>Application</tag>
-                                    <value>Network</value>
+                                    <value>Interface Speed</value>
+                                </tag>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
                                 </tag>
                             </tags>
                         </item_prototype>
@@ -335,9 +414,49 @@
                             <tags>
                                 <tag>
                                     <tag>Application</tag>
-                                    <value>Network</value>
+                                    <value>Interface Speed</value>
+                                </tag>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
                                 </tag>
                             </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>650af0d82a9f495db7b174940d56a873</uuid>
+                            <name>Interface {#IFNAME} : Status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.2.2.1.8.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.status[ifOperStatus.{#SNMPINDEX}]</key>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <valuemap>
+                                <name>ifOperStatus</name>
+                            </valuemap>
+                            <tags>
+                                <tag>
+                                    <tag>Application</tag>
+                                    <value>interface status</value>
+                                </tag>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
+                                </tag>
+                            </tags>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>ed8cfda8eff44c01a8c18956bb18aef5</uuid>
+                                    <expression>last(/EdgeMAX SNMPv2/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)&lt;&gt;last(/EdgeMAX SNMPv2/net.if.status[ifOperStatus.{#SNMPINDEX}],#2) and last(/EdgeMAX SNMPv2/net.if.status[ifOperStatus.{#SNMPINDEX}],#2)=1</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>last(/EdgeMAX SNMPv2/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)=1</recovery_expression>
+                                    <name>EdgeMAX: Interface status has changed</name>
+                                    <event_name>EdgeMAX: Interface {#IFNAME} on {HOST.HOST} status has changed from up (1).</event_name>
+                                    <opdata>Interface {#IFNAME} is currently {ITEM.VALUE1}</opdata>
+                                    <priority>AVERAGE</priority>
+                                    <description>Interface status has changed from up (1). Acknowledge to close the problem manually or get the interface up again to close the problem automatically</description>
+                                    <manual_close>YES</manual_close>
+                                </trigger_prototype>
+                            </trigger_prototypes>
                         </item_prototype>
                     </item_prototypes>
                     <graph_prototypes>
@@ -425,6 +544,7 @@
                             <widgets>
                                 <widget>
                                     <type>GRAPH_CLASSIC</type>
+                                    <y>2</y>
                                     <width>12</width>
                                     <height>5</height>
                                     <fields>
@@ -441,6 +561,7 @@
                                 <widget>
                                     <type>GRAPH_CLASSIC</type>
                                     <x>12</x>
+                                    <y>2</y>
                                     <width>12</width>
                                     <height>5</height>
                                     <fields>
@@ -456,9 +577,9 @@
                                 </widget>
                                 <widget>
                                     <type>GRAPH_CLASSIC</type>
-                                    <y>5</y>
+                                    <y>7</y>
                                     <width>24</width>
-                                    <height>6</height>
+                                    <height>5</height>
                                     <fields>
                                         <field>
                                             <type>GRAPH</type>
@@ -470,11 +591,157 @@
                                         </field>
                                     </fields>
                                 </widget>
+                                <widget>
+                                    <type>GRAPH_CLASSIC</type>
+                                    <x>12</x>
+                                    <y>12</y>
+                                    <width>12</width>
+                                    <height>5</height>
+                                    <fields>
+                                        <field>
+                                            <type>GRAPH</type>
+                                            <name>graphid</name>
+                                            <value>
+                                                <host>EdgeMAX SNMPv2</host>
+                                                <name>Generic by SNMP: Ping lost</name>
+                                            </value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>GRAPH_CLASSIC</type>
+                                    <y>12</y>
+                                    <width>12</width>
+                                    <height>5</height>
+                                    <fields>
+                                        <field>
+                                            <type>GRAPH</type>
+                                            <name>graphid</name>
+                                            <value>
+                                                <host>EdgeMAX SNMPv2</host>
+                                                <name>Generic by SNMP: Ping time</name>
+                                            </value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>ITEM</type>
+                                    <width>8</width>
+                                    <hide_header>YES</hide_header>
+                                    <fields>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>show</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>adv_conf</name>
+                                            <value>1</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>units_show</name>
+                                            <value>0</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>units_bold</name>
+                                            <value>0</value>
+                                        </field>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid</name>
+                                            <value>
+                                                <host>EdgeMAX SNMPv2</host>
+                                                <key>system.name</key>
+                                            </value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>ITEM</type>
+                                    <name>Uptime (hardware)</name>
+                                    <x>12</x>
+                                    <width>4</width>
+                                    <fields>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>show</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid</name>
+                                            <value>
+                                                <host>EdgeMAX SNMPv2</host>
+                                                <key>system.hw.uptime[hrSystemUptime.0]</key>
+                                            </value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>ITEM</type>
+                                    <name>Uptime (network)</name>
+                                    <x>8</x>
+                                    <width>4</width>
+                                    <fields>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>show</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid</name>
+                                            <value>
+                                                <host>EdgeMAX SNMPv2</host>
+                                                <key>system.net.uptime[sysUpTime.0]</key>
+                                            </value>
+                                        </field>
+                                    </fields>
+                                </widget>
                             </widgets>
                         </page>
                     </pages>
                 </dashboard>
             </dashboards>
+            <valuemaps>
+                <valuemap>
+                    <uuid>5040d26951114decbb582ae0589c463a</uuid>
+                    <name>ifOperStatus</name>
+                    <mappings>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>up</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>down</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>3</value>
+                            <newvalue>testing</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>4</value>
+                            <newvalue>unknown</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>5</value>
+                            <newvalue>dormant</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>6</value>
+                            <newvalue>notPresent</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>7</value>
+                            <newvalue>lowerLayerDow</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+            </valuemaps>
         </template>
     </templates>
     <graphs>
@@ -540,7 +807,7 @@
                     <calc_fnc>ALL</calc_fnc>
                     <item>
                         <host>EdgeMAX SNMPv2</host>
-                        <key>LoadMinute</key>
+                        <key>Load1Minute</key>
                     </item>
                 </graph_item>
                 <graph_item>

--- a/zabbix6.0/zbx_edgemax_template.xml
+++ b/zabbix6.0/zbx_edgemax_template.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>6.0</version>
-    <date>2023-09-25T16:59:04Z</date>
-    <groups>
-        <group><?xml version="1.0" encoding="UTF-8"?>
-<zabbix_export>
-    <version>6.0</version>
-    <date>2023-09-25T16:59:04Z</date>
+    <date>2023-09-26T13:33:58Z</date>
     <groups>
         <group>
             <uuid>36bff6c29af64692839d077febfc7079</uuid>
@@ -30,14 +25,45 @@
             </groups>
             <items>
                 <item>
+                    <uuid>268fe8c15d99415dafd32fec95ebb9f0</uuid>
+                    <name>Load average last 5 minute</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.10.1.3.2</snmp_oid>
+                    <key>Load5Minute</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <description>5 minute Load</description>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>System Info</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>effdbb0807574ffa80fa9ee2deaf9685</uuid>
+                    <name>Load average last 15 minutes</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.10.1.3.3</snmp_oid>
+                    <key>Load15Minute</key>
+                    <history>1d</history>
+                    <value_type>FLOAT</value_type>
+                    <description>15 minute Load</description>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>System Info</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
                     <uuid>62c2558cc3b24573bb425869bd680ae0</uuid>
                     <name>Load average last 1 minute</name>
                     <type>SNMP_AGENT</type>
                     <snmp_oid>1.3.6.1.4.1.2021.10.1.3.1</snmp_oid>
                     <key>LoadMinute</key>
                     <history>1d</history>
-                    <trends>0</trends>
-                    <value_type>CHAR</value_type>
+                    <value_type>FLOAT</value_type>
                     <tags>
                         <tag>
                             <tag>Application</tag>
@@ -50,10 +76,16 @@
                             <expression>last(/EdgeMAX SNMPv2/LoadMinute)&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}</expression>
                             <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
                             <recovery_expression>last(/EdgeMAX SNMPv2/LoadMinute)&lt;{$LOAD_AVG_PER_CPU.MAX.WARN}</recovery_expression>
-                            <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 1m)</name>
+                            <name>EdgeMAX: Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 1m)</name>
                             <opdata>Load averages(1m): {ITEM.LASTVALUE1}</opdata>
                             <priority>AVERAGE</priority>
                             <description>Per CPU load average is too high. Your system may be slow to respond.</description>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>performance</value>
+                                </tag>
+                            </tags>
                         </trigger>
                     </triggers>
                 </item>
@@ -199,10 +231,16 @@
                             <expression>min(/EdgeMAX SNMPv2/MemUtil,5m)&gt;{$MEMORY.UTIL.MAX}</expression>
                             <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
                             <recovery_expression>max(/EdgeMAX SNMPv2/MemUtil,5m)&lt;{$MEMORY.UTIL.MAX}</recovery_expression>
-                            <name>High memory utilization ( &gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
+                            <name>EdgeMAX: High memory utilization ( &gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
                             <opdata>Memory utilization: {ITEM.LASTVALUE1}</opdata>
                             <priority>WARNING</priority>
                             <description>The system is running out of free memory.</description>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>performance</value>
+                                </tag>
+                            </tags>
                         </trigger>
                     </triggers>
                 </item>
@@ -302,6 +340,32 @@
                             </tags>
                         </item_prototype>
                     </item_prototypes>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <uuid>50b02b31a5c849ed8a469cbc1f74bb1f</uuid>
+                            <name>Interface {#IFNAME}: Network traffic</name>
+                            <ymin_type_1>FIXED</ymin_type_1>
+                            <graph_items>
+                                <graph_item>
+                                    <color>F63100</color>
+                                    <calc_fnc>ALL</calc_fnc>
+                                    <item>
+                                        <host>EdgeMAX SNMPv2</host>
+                                        <key>net.if.in[ifHCInOctets.{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>1</sortorder>
+                                    <color>199C0D</color>
+                                    <calc_fnc>ALL</calc_fnc>
+                                    <item>
+                                        <host>EdgeMAX SNMPv2</host>
+                                        <key>net.if.out[ifHCOutOctets.{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
                 </discovery_rule>
             </discovery_rules>
             <macros>
@@ -316,316 +380,188 @@
                     <description>This macro is used as a threshold in memory utilization trigger.</description>
                 </macro>
             </macros>
+            <dashboards>
+                <dashboard>
+                    <uuid>f58a92b380334662982059edbee55cd7</uuid>
+                    <name>EdgeMAX: Network Interfaces</name>
+                    <pages>
+                        <page>
+                            <widgets>
+                                <widget>
+                                    <type>GRAPH_PROTOTYPE</type>
+                                    <name>EdgeMAX: Network Interfaces</name>
+                                    <width>24</width>
+                                    <height>12</height>
+                                    <fields>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>columns</name>
+                                            <value>3</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>rows</name>
+                                            <value>3</value>
+                                        </field>
+                                        <field>
+                                            <type>GRAPH_PROTOTYPE</type>
+                                            <name>graphid</name>
+                                            <value>
+                                                <host>EdgeMAX SNMPv2</host>
+                                                <name>Interface {#IFNAME}: Network traffic</name>
+                                            </value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                            </widgets>
+                        </page>
+                    </pages>
+                </dashboard>
+                <dashboard>
+                    <uuid>04ea8df74b3c4bfaaebb86184b65dc23</uuid>
+                    <name>EdgeMAX: System Statistics</name>
+                    <pages>
+                        <page>
+                            <widgets>
+                                <widget>
+                                    <type>GRAPH_CLASSIC</type>
+                                    <width>12</width>
+                                    <height>5</height>
+                                    <fields>
+                                        <field>
+                                            <type>GRAPH</type>
+                                            <name>graphid</name>
+                                            <value>
+                                                <host>EdgeMAX SNMPv2</host>
+                                                <name>EdgeMAX:  Memory usage</name>
+                                            </value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>GRAPH_CLASSIC</type>
+                                    <x>12</x>
+                                    <width>12</width>
+                                    <height>5</height>
+                                    <fields>
+                                        <field>
+                                            <type>GRAPH</type>
+                                            <name>graphid</name>
+                                            <value>
+                                                <host>EdgeMAX SNMPv2</host>
+                                                <name>EdgeMAX: Memory Used</name>
+                                            </value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>GRAPH_CLASSIC</type>
+                                    <y>5</y>
+                                    <width>24</width>
+                                    <height>6</height>
+                                    <fields>
+                                        <field>
+                                            <type>GRAPH</type>
+                                            <name>graphid</name>
+                                            <value>
+                                                <host>EdgeMAX SNMPv2</host>
+                                                <name>EdgeMAX: System Load</name>
+                                            </value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                            </widgets>
+                        </page>
+                    </pages>
+                </dashboard>
+            </dashboards>
         </template>
     </templates>
-</zabbix_export>
-
-            <name>Templates/Network devices</name>
-        </group>
-    </groups>
-    <templates>
-        <template>
-            <uuid>51e0e9a9f0ca49569840767018bb586a</uuid>
-            <template>EdgeMAX SNMPv2</template>
-            <name>EdgeMAX SNMPv2</name>
-            <templates>
-                <template>
-                    <name>Generic by SNMP</name>
-                </template>
-            </templates>
-            <groups>
-                <group>
-                    <name>Templates/Network devices</name>
-                </group>
-            </groups>
-            <items>
-                <item>
-                    <uuid>62c2558cc3b24573bb425869bd680ae0</uuid>
-                    <name>Load average last 1 minute</name>
-                    <type>SNMP_AGENT</type>
-                    <snmp_oid>1.3.6.1.4.1.2021.10.1.3.1</snmp_oid>
-                    <key>LoadMinute</key>
-                    <history>1d</history>
-                    <trends>0</trends>
-                    <value_type>CHAR</value_type>
-                    <tags>
-                        <tag>
-                            <tag>Application</tag>
-                            <value>System Info</value>
-                        </tag>
-                    </tags>
-                    <triggers>
-                        <trigger>
-                            <uuid>229564ad1b274f4887812a3af0ffafc6</uuid>
-                            <expression>last(/EdgeMAX SNMPv2/LoadMinute)&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}</expression>
-                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                            <recovery_expression>last(/EdgeMAX SNMPv2/LoadMinute)&lt;{$LOAD_AVG_PER_CPU.MAX.WARN}</recovery_expression>
-                            <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 1m)</name>
-                            <opdata>Load averages(1m): {ITEM.LASTVALUE1}</opdata>
-                            <priority>AVERAGE</priority>
-                            <description>Per CPU load average is too high. Your system may be slow to respond.</description>
-                        </trigger>
-                    </triggers>
-                </item>
-                <item>
-                    <uuid>55d17189b0894e5bb5aed103ca860527</uuid>
-                    <name>Total amount of available memory</name>
-                    <type>SNMP_AGENT</type>
-                    <snmp_oid>1.3.6.1.4.1.2021.4.6.0</snmp_oid>
-                    <key>MemAvailable</key>
-                    <history>7d</history>
-                    <trends>0</trends>
-                    <units>b</units>
-                    <preprocessing>
-                        <step>
-                            <type>MULTIPLIER</type>
-                            <parameters>
-                                <parameter>1000</parameter>
-                            </parameters>
-                        </step>
-                    </preprocessing>
-                    <tags>
-                        <tag>
-                            <tag>Application</tag>
-                            <value>Memory</value>
-                        </tag>
-                    </tags>
-                </item>
-                <item>
-                    <uuid>8a61a3d93e194ee7a44420db20b37de6</uuid>
-                    <name>Total amount of buffers</name>
-                    <type>SNMP_AGENT</type>
-                    <snmp_oid>1.3.6.1.4.1.2021.4.14.0</snmp_oid>
-                    <key>MemBuffers</key>
-                    <history>7d</history>
-                    <trends>0</trends>
-                    <units>b</units>
-                    <preprocessing>
-                        <step>
-                            <type>MULTIPLIER</type>
-                            <parameters>
-                                <parameter>1000</parameter>
-                            </parameters>
-                        </step>
-                    </preprocessing>
-                    <tags>
-                        <tag>
-                            <tag>Application</tag>
-                            <value>Memory</value>
-                        </tag>
-                    </tags>
-                </item>
-                <item>
-                    <uuid>c858f465d2bb4651a23bcfa86596c371</uuid>
-                    <name>Total amount of cached</name>
-                    <type>SNMP_AGENT</type>
-                    <snmp_oid>1.3.6.1.4.1.2021.4.15.0</snmp_oid>
-                    <key>MemCached</key>
-                    <history>7d</history>
-                    <trends>0</trends>
-                    <units>b</units>
-                    <preprocessing>
-                        <step>
-                            <type>MULTIPLIER</type>
-                            <parameters>
-                                <parameter>1000</parameter>
-                            </parameters>
-                        </step>
-                    </preprocessing>
-                    <tags>
-                        <tag>
-                            <tag>Application</tag>
-                            <value>Memory</value>
-                        </tag>
-                    </tags>
-                </item>
-                <item>
-                    <uuid>ba758bc30b3a47f69f834e6815589a2d</uuid>
-                    <name>Total amount of memory</name>
-                    <type>SNMP_AGENT</type>
-                    <snmp_oid>1.3.6.1.4.1.2021.4.5.0</snmp_oid>
-                    <key>MemTotal</key>
-                    <history>7d</history>
-                    <trends>0</trends>
-                    <units>b</units>
-                    <preprocessing>
-                        <step>
-                            <type>MULTIPLIER</type>
-                            <parameters>
-                                <parameter>1000</parameter>
-                            </parameters>
-                        </step>
-                    </preprocessing>
-                    <tags>
-                        <tag>
-                            <tag>Application</tag>
-                            <value>Memory</value>
-                        </tag>
-                    </tags>
-                </item>
-                <item>
-                    <uuid>b3f2f99e384a492d8d838c007a9f1081</uuid>
-                    <name>Used memory</name>
-                    <type>CALCULATED</type>
-                    <key>MemUsed</key>
-                    <history>7d</history>
-                    <trends>0</trends>
-                    <units>B</units>
-                    <params>last(//MemTotal)-last(//MemAvailable)</params>
-                    <tags>
-                        <tag>
-                            <tag>Application</tag>
-                            <value>Memory</value>
-                        </tag>
-                    </tags>
-                </item>
-                <item>
-                    <uuid>74e161402bc1440e8d30a413c7a0968e</uuid>
-                    <name>Memory utizilation</name>
-                    <type>CALCULATED</type>
-                    <key>MemUtil</key>
-                    <history>7d</history>
-                    <trends>0</trends>
-                    <value_type>FLOAT</value_type>
-                    <units>%</units>
-                    <params>(last(//MemUsed)-last(//MemBuffers)-last(//MemCached))/last(//MemTotal)*100</params>
-                    <preprocessing>
-                        <step>
-                            <type>JAVASCRIPT</type>
-                            <parameters>
-                                <parameter>return Math.floor(value)</parameter>
-                            </parameters>
-                        </step>
-                    </preprocessing>
-                    <tags>
-                        <tag>
-                            <tag>Application</tag>
-                            <value>Memory</value>
-                        </tag>
-                    </tags>
-                    <triggers>
-                        <trigger>
-                            <uuid>a30deff68b824ca2b8cd81ae889cdf2f</uuid>
-                            <expression>min(/EdgeMAX SNMPv2/MemUtil,5m)&gt;{$MEMORY.UTIL.MAX}</expression>
-                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-                            <recovery_expression>max(/EdgeMAX SNMPv2/MemUtil,5m)&lt;{$MEMORY.UTIL.MAX}</recovery_expression>
-                            <name>High memory utilization ( &gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
-                            <opdata>Memory utilization: {ITEM.LASTVALUE1}</opdata>
-                            <priority>WARNING</priority>
-                            <description>The system is running out of free memory.</description>
-                        </trigger>
-                    </triggers>
-                </item>
-            </items>
-            <discovery_rules>
-                <discovery_rule>
-                    <uuid>36f64bd4b35d41d9a8fde299df72ca9a</uuid>
-                    <name>Network interfaces discovery</name>
-                    <type>SNMP_AGENT</type>
-                    <snmp_oid>discovery[{#IFOPERSTATUS},1.3.6.1.2.1.2.2.1.8,{#IFNAME},1.3.6.1.2.1.31.1.1.1.1]</snmp_oid>
-                    <key>NetworkInterface</key>
-                    <delay>1d</delay>
-                    <item_prototypes>
-                        <item_prototype>
-                            <uuid>a922c4529f82490287f0cbb29997f331</uuid>
-                            <name>Interface {#IFNAME} : Bits received</name>
-                            <type>SNMP_AGENT</type>
-                            <snmp_oid>1.3.6.1.2.1.31.1.1.1.6.{#SNMPINDEX}</snmp_oid>
-                            <key>net.if.in[ifHCInOctets.{#SNMPINDEX}]</key>
-                            <history>7d</history>
-                            <trends>0</trends>
-                            <units>bps</units>
-                            <preprocessing>
-                                <step>
-                                    <type>CHANGE_PER_SECOND</type>
-                                    <parameters>
-                                        <parameter/>
-                                    </parameters>
-                                </step>
-                                <step>
-                                    <type>MULTIPLIER</type>
-                                    <parameters>
-                                        <parameter>8</parameter>
-                                    </parameters>
-                                </step>
-                            </preprocessing>
-                            <tags>
-                                <tag>
-                                    <tag>Application</tag>
-                                    <value>Network</value>
-                                </tag>
-                            </tags>
-                        </item_prototype>
-                        <item_prototype>
-                            <uuid>b067d0d9f6cf4212a35849f2d6d6309f</uuid>
-                            <name>Interface {#IFNAME} : Bits sent</name>
-                            <type>SNMP_AGENT</type>
-                            <snmp_oid>1.3.6.1.2.1.31.1.1.1.10.{#SNMPINDEX}</snmp_oid>
-                            <key>net.if.out[ifHCOutOctets.{#SNMPINDEX}]</key>
-                            <history>7d</history>
-                            <trends>0</trends>
-                            <units>bps</units>
-                            <preprocessing>
-                                <step>
-                                    <type>CHANGE_PER_SECOND</type>
-                                    <parameters>
-                                        <parameter/>
-                                    </parameters>
-                                </step>
-                                <step>
-                                    <type>MULTIPLIER</type>
-                                    <parameters>
-                                        <parameter>8</parameter>
-                                    </parameters>
-                                </step>
-                            </preprocessing>
-                            <tags>
-                                <tag>
-                                    <tag>Application</tag>
-                                    <value>Network</value>
-                                </tag>
-                            </tags>
-                        </item_prototype>
-                        <item_prototype>
-                            <uuid>bf8592a3ac8246f7b883b387438c80c2</uuid>
-                            <name>Interface {#IFNAME} : Speed</name>
-                            <type>SNMP_AGENT</type>
-                            <snmp_oid>1.3.6.1.2.1.2.2.1.5.{#SNMPINDEX}</snmp_oid>
-                            <key>net.if.speed[ifHighSpeed.{#SNMPINDEX}]</key>
-                            <delay>10m</delay>
-                            <history>1d</history>
-                            <trends>0</trends>
-                            <units>bps</units>
-                            <preprocessing>
-                                <step>
-                                    <type>DISCARD_UNCHANGED_HEARTBEAT</type>
-                                    <parameters>
-                                        <parameter>1h</parameter>
-                                    </parameters>
-                                </step>
-                            </preprocessing>
-                            <tags>
-                                <tag>
-                                    <tag>Application</tag>
-                                    <value>Network</value>
-                                </tag>
-                            </tags>
-                        </item_prototype>
-                    </item_prototypes>
-                </discovery_rule>
-            </discovery_rules>
-            <macros>
-                <macro>
-                    <macro>{$LOAD_AVG_PER_CPU.MAX.WARN}</macro>
-                    <value>1.5</value>
-                    <description>This macro is used as a threshold in memory utilization trigger.</description>
-                </macro>
-                <macro>
-                    <macro>{$MEMORY.UTIL.MAX}</macro>
-                    <value>90</value>
-                    <description>This macro is used as a threshold in memory utilization trigger.</description>
-                </macro>
-            </macros>
-        </template>
-    </templates>
+    <graphs>
+        <graph>
+            <uuid>66415b709399470bb181f7c604f7b00a</uuid>
+            <name>EdgeMAX:  Memory usage</name>
+            <height>500</height>
+            <show_work_period>NO</show_work_period>
+            <show_triggers>NO</show_triggers>
+            <type>STACKED</type>
+            <graph_items>
+                <graph_item>
+                    <color>F63100</color>
+                    <calc_fnc>MIN</calc_fnc>
+                    <item>
+                        <host>EdgeMAX SNMPv2</host>
+                        <key>MemBuffers</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>1</sortorder>
+                    <color>2774A4</color>
+                    <calc_fnc>MIN</calc_fnc>
+                    <item>
+                        <host>EdgeMAX SNMPv2</host>
+                        <key>MemCached</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>2</sortorder>
+                    <color>199C0D</color>
+                    <calc_fnc>MIN</calc_fnc>
+                    <item>
+                        <host>EdgeMAX SNMPv2</host>
+                        <key>MemAvailable</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <uuid>f260a63bc3b04c3b80b47f83bb05ed9c</uuid>
+            <name>EdgeMAX: Memory Used</name>
+            <percent_right>50</percent_right>
+            <ymin_type_1>FIXED</ymin_type_1>
+            <graph_items>
+                <graph_item>
+                    <color>199C0D</color>
+                    <calc_fnc>ALL</calc_fnc>
+                    <item>
+                        <host>EdgeMAX SNMPv2</host>
+                        <key>MemUtil</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <uuid>f6837489bd7246fcb6296b62a604b6a1</uuid>
+            <name>EdgeMAX: System Load</name>
+            <ymin_type_1>FIXED</ymin_type_1>
+            <graph_items>
+                <graph_item>
+                    <color>199C0D</color>
+                    <calc_fnc>ALL</calc_fnc>
+                    <item>
+                        <host>EdgeMAX SNMPv2</host>
+                        <key>LoadMinute</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>1</sortorder>
+                    <color>F63100</color>
+                    <calc_fnc>ALL</calc_fnc>
+                    <item>
+                        <host>EdgeMAX SNMPv2</host>
+                        <key>Load5Minute</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>2</sortorder>
+                    <color>2774A4</color>
+                    <calc_fnc>ALL</calc_fnc>
+                    <item>
+                        <host>EdgeMAX SNMPv2</host>
+                        <key>Load15Minute</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+    </graphs>
 </zabbix_export>

--- a/zabbix6.0/zbx_edgemax_template.xml
+++ b/zabbix6.0/zbx_edgemax_template.xml
@@ -1,0 +1,631 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>6.0</version>
+    <date>2023-09-25T16:59:04Z</date>
+    <groups>
+        <group><?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>6.0</version>
+    <date>2023-09-25T16:59:04Z</date>
+    <groups>
+        <group>
+            <uuid>36bff6c29af64692839d077febfc7079</uuid>
+            <name>Templates/Network devices</name>
+        </group>
+    </groups>
+    <templates>
+        <template>
+            <uuid>51e0e9a9f0ca49569840767018bb586a</uuid>
+            <template>EdgeMAX SNMPv2</template>
+            <name>EdgeMAX SNMPv2</name>
+            <templates>
+                <template>
+                    <name>Generic by SNMP</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Templates/Network devices</name>
+                </group>
+            </groups>
+            <items>
+                <item>
+                    <uuid>62c2558cc3b24573bb425869bd680ae0</uuid>
+                    <name>Load average last 1 minute</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.10.1.3.1</snmp_oid>
+                    <key>LoadMinute</key>
+                    <history>1d</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>System Info</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>229564ad1b274f4887812a3af0ffafc6</uuid>
+                            <expression>last(/EdgeMAX SNMPv2/LoadMinute)&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>last(/EdgeMAX SNMPv2/LoadMinute)&lt;{$LOAD_AVG_PER_CPU.MAX.WARN}</recovery_expression>
+                            <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 1m)</name>
+                            <opdata>Load averages(1m): {ITEM.LASTVALUE1}</opdata>
+                            <priority>AVERAGE</priority>
+                            <description>Per CPU load average is too high. Your system may be slow to respond.</description>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>55d17189b0894e5bb5aed103ca860527</uuid>
+                    <name>Total amount of available memory</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.4.6.0</snmp_oid>
+                    <key>MemAvailable</key>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <units>b</units>
+                    <preprocessing>
+                        <step>
+                            <type>MULTIPLIER</type>
+                            <parameters>
+                                <parameter>1000</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Memory</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>8a61a3d93e194ee7a44420db20b37de6</uuid>
+                    <name>Total amount of buffers</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.4.14.0</snmp_oid>
+                    <key>MemBuffers</key>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <units>b</units>
+                    <preprocessing>
+                        <step>
+                            <type>MULTIPLIER</type>
+                            <parameters>
+                                <parameter>1000</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Memory</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>c858f465d2bb4651a23bcfa86596c371</uuid>
+                    <name>Total amount of cached</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.4.15.0</snmp_oid>
+                    <key>MemCached</key>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <units>b</units>
+                    <preprocessing>
+                        <step>
+                            <type>MULTIPLIER</type>
+                            <parameters>
+                                <parameter>1000</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Memory</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>ba758bc30b3a47f69f834e6815589a2d</uuid>
+                    <name>Total amount of memory</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.4.5.0</snmp_oid>
+                    <key>MemTotal</key>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <units>b</units>
+                    <preprocessing>
+                        <step>
+                            <type>MULTIPLIER</type>
+                            <parameters>
+                                <parameter>1000</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Memory</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>b3f2f99e384a492d8d838c007a9f1081</uuid>
+                    <name>Used memory</name>
+                    <type>CALCULATED</type>
+                    <key>MemUsed</key>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <units>B</units>
+                    <params>last(//MemTotal)-last(//MemAvailable)</params>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Memory</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>74e161402bc1440e8d30a413c7a0968e</uuid>
+                    <name>Memory utizilation</name>
+                    <type>CALCULATED</type>
+                    <key>MemUtil</key>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <value_type>FLOAT</value_type>
+                    <units>%</units>
+                    <params>(last(//MemUsed)-last(//MemBuffers)-last(//MemCached))/last(//MemTotal)*100</params>
+                    <preprocessing>
+                        <step>
+                            <type>JAVASCRIPT</type>
+                            <parameters>
+                                <parameter>return Math.floor(value)</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Memory</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>a30deff68b824ca2b8cd81ae889cdf2f</uuid>
+                            <expression>min(/EdgeMAX SNMPv2/MemUtil,5m)&gt;{$MEMORY.UTIL.MAX}</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>max(/EdgeMAX SNMPv2/MemUtil,5m)&lt;{$MEMORY.UTIL.MAX}</recovery_expression>
+                            <name>High memory utilization ( &gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
+                            <opdata>Memory utilization: {ITEM.LASTVALUE1}</opdata>
+                            <priority>WARNING</priority>
+                            <description>The system is running out of free memory.</description>
+                        </trigger>
+                    </triggers>
+                </item>
+            </items>
+            <discovery_rules>
+                <discovery_rule>
+                    <uuid>36f64bd4b35d41d9a8fde299df72ca9a</uuid>
+                    <name>Network interfaces discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#IFOPERSTATUS},1.3.6.1.2.1.2.2.1.8,{#IFNAME},1.3.6.1.2.1.31.1.1.1.1]</snmp_oid>
+                    <key>NetworkInterface</key>
+                    <delay>1d</delay>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>a922c4529f82490287f0cbb29997f331</uuid>
+                            <name>Interface {#IFNAME} : Bits received</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.31.1.1.1.6.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.in[ifHCInOctets.{#SNMPINDEX}]</key>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <units>bps</units>
+                            <preprocessing>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <parameters>
+                                        <parameter/>
+                                    </parameters>
+                                </step>
+                                <step>
+                                    <type>MULTIPLIER</type>
+                                    <parameters>
+                                        <parameter>8</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>Application</tag>
+                                    <value>Network</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>b067d0d9f6cf4212a35849f2d6d6309f</uuid>
+                            <name>Interface {#IFNAME} : Bits sent</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.31.1.1.1.10.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.out[ifHCOutOctets.{#SNMPINDEX}]</key>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <units>bps</units>
+                            <preprocessing>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <parameters>
+                                        <parameter/>
+                                    </parameters>
+                                </step>
+                                <step>
+                                    <type>MULTIPLIER</type>
+                                    <parameters>
+                                        <parameter>8</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>Application</tag>
+                                    <value>Network</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>bf8592a3ac8246f7b883b387438c80c2</uuid>
+                            <name>Interface {#IFNAME} : Speed</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.2.2.1.5.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.speed[ifHighSpeed.{#SNMPINDEX}]</key>
+                            <delay>10m</delay>
+                            <history>1d</history>
+                            <trends>0</trends>
+                            <units>bps</units>
+                            <preprocessing>
+                                <step>
+                                    <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                                    <parameters>
+                                        <parameter>1h</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>Application</tag>
+                                    <value>Network</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+            </discovery_rules>
+            <macros>
+                <macro>
+                    <macro>{$LOAD_AVG_PER_CPU.MAX.WARN}</macro>
+                    <value>1.5</value>
+                    <description>This macro is used as a threshold in memory utilization trigger.</description>
+                </macro>
+                <macro>
+                    <macro>{$MEMORY.UTIL.MAX}</macro>
+                    <value>90</value>
+                    <description>This macro is used as a threshold in memory utilization trigger.</description>
+                </macro>
+            </macros>
+        </template>
+    </templates>
+</zabbix_export>
+
+            <name>Templates/Network devices</name>
+        </group>
+    </groups>
+    <templates>
+        <template>
+            <uuid>51e0e9a9f0ca49569840767018bb586a</uuid>
+            <template>EdgeMAX SNMPv2</template>
+            <name>EdgeMAX SNMPv2</name>
+            <templates>
+                <template>
+                    <name>Generic by SNMP</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Templates/Network devices</name>
+                </group>
+            </groups>
+            <items>
+                <item>
+                    <uuid>62c2558cc3b24573bb425869bd680ae0</uuid>
+                    <name>Load average last 1 minute</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.10.1.3.1</snmp_oid>
+                    <key>LoadMinute</key>
+                    <history>1d</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>System Info</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>229564ad1b274f4887812a3af0ffafc6</uuid>
+                            <expression>last(/EdgeMAX SNMPv2/LoadMinute)&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>last(/EdgeMAX SNMPv2/LoadMinute)&lt;{$LOAD_AVG_PER_CPU.MAX.WARN}</recovery_expression>
+                            <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 1m)</name>
+                            <opdata>Load averages(1m): {ITEM.LASTVALUE1}</opdata>
+                            <priority>AVERAGE</priority>
+                            <description>Per CPU load average is too high. Your system may be slow to respond.</description>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>55d17189b0894e5bb5aed103ca860527</uuid>
+                    <name>Total amount of available memory</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.4.6.0</snmp_oid>
+                    <key>MemAvailable</key>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <units>b</units>
+                    <preprocessing>
+                        <step>
+                            <type>MULTIPLIER</type>
+                            <parameters>
+                                <parameter>1000</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Memory</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>8a61a3d93e194ee7a44420db20b37de6</uuid>
+                    <name>Total amount of buffers</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.4.14.0</snmp_oid>
+                    <key>MemBuffers</key>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <units>b</units>
+                    <preprocessing>
+                        <step>
+                            <type>MULTIPLIER</type>
+                            <parameters>
+                                <parameter>1000</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Memory</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>c858f465d2bb4651a23bcfa86596c371</uuid>
+                    <name>Total amount of cached</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.4.15.0</snmp_oid>
+                    <key>MemCached</key>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <units>b</units>
+                    <preprocessing>
+                        <step>
+                            <type>MULTIPLIER</type>
+                            <parameters>
+                                <parameter>1000</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Memory</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>ba758bc30b3a47f69f834e6815589a2d</uuid>
+                    <name>Total amount of memory</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.2021.4.5.0</snmp_oid>
+                    <key>MemTotal</key>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <units>b</units>
+                    <preprocessing>
+                        <step>
+                            <type>MULTIPLIER</type>
+                            <parameters>
+                                <parameter>1000</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Memory</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>b3f2f99e384a492d8d838c007a9f1081</uuid>
+                    <name>Used memory</name>
+                    <type>CALCULATED</type>
+                    <key>MemUsed</key>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <units>B</units>
+                    <params>last(//MemTotal)-last(//MemAvailable)</params>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Memory</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>74e161402bc1440e8d30a413c7a0968e</uuid>
+                    <name>Memory utizilation</name>
+                    <type>CALCULATED</type>
+                    <key>MemUtil</key>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <value_type>FLOAT</value_type>
+                    <units>%</units>
+                    <params>(last(//MemUsed)-last(//MemBuffers)-last(//MemCached))/last(//MemTotal)*100</params>
+                    <preprocessing>
+                        <step>
+                            <type>JAVASCRIPT</type>
+                            <parameters>
+                                <parameter>return Math.floor(value)</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>Application</tag>
+                            <value>Memory</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>a30deff68b824ca2b8cd81ae889cdf2f</uuid>
+                            <expression>min(/EdgeMAX SNMPv2/MemUtil,5m)&gt;{$MEMORY.UTIL.MAX}</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>max(/EdgeMAX SNMPv2/MemUtil,5m)&lt;{$MEMORY.UTIL.MAX}</recovery_expression>
+                            <name>High memory utilization ( &gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
+                            <opdata>Memory utilization: {ITEM.LASTVALUE1}</opdata>
+                            <priority>WARNING</priority>
+                            <description>The system is running out of free memory.</description>
+                        </trigger>
+                    </triggers>
+                </item>
+            </items>
+            <discovery_rules>
+                <discovery_rule>
+                    <uuid>36f64bd4b35d41d9a8fde299df72ca9a</uuid>
+                    <name>Network interfaces discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#IFOPERSTATUS},1.3.6.1.2.1.2.2.1.8,{#IFNAME},1.3.6.1.2.1.31.1.1.1.1]</snmp_oid>
+                    <key>NetworkInterface</key>
+                    <delay>1d</delay>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>a922c4529f82490287f0cbb29997f331</uuid>
+                            <name>Interface {#IFNAME} : Bits received</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.31.1.1.1.6.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.in[ifHCInOctets.{#SNMPINDEX}]</key>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <units>bps</units>
+                            <preprocessing>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <parameters>
+                                        <parameter/>
+                                    </parameters>
+                                </step>
+                                <step>
+                                    <type>MULTIPLIER</type>
+                                    <parameters>
+                                        <parameter>8</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>Application</tag>
+                                    <value>Network</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>b067d0d9f6cf4212a35849f2d6d6309f</uuid>
+                            <name>Interface {#IFNAME} : Bits sent</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.31.1.1.1.10.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.out[ifHCOutOctets.{#SNMPINDEX}]</key>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <units>bps</units>
+                            <preprocessing>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <parameters>
+                                        <parameter/>
+                                    </parameters>
+                                </step>
+                                <step>
+                                    <type>MULTIPLIER</type>
+                                    <parameters>
+                                        <parameter>8</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>Application</tag>
+                                    <value>Network</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>bf8592a3ac8246f7b883b387438c80c2</uuid>
+                            <name>Interface {#IFNAME} : Speed</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.2.2.1.5.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.speed[ifHighSpeed.{#SNMPINDEX}]</key>
+                            <delay>10m</delay>
+                            <history>1d</history>
+                            <trends>0</trends>
+                            <units>bps</units>
+                            <preprocessing>
+                                <step>
+                                    <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                                    <parameters>
+                                        <parameter>1h</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>Application</tag>
+                                    <value>Network</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+            </discovery_rules>
+            <macros>
+                <macro>
+                    <macro>{$LOAD_AVG_PER_CPU.MAX.WARN}</macro>
+                    <value>1.5</value>
+                    <description>This macro is used as a threshold in memory utilization trigger.</description>
+                </macro>
+                <macro>
+                    <macro>{$MEMORY.UTIL.MAX}</macro>
+                    <value>90</value>
+                    <description>This macro is used as a threshold in memory utilization trigger.</description>
+                </macro>
+            </macros>
+        </template>
+    </templates>
+</zabbix_export>


### PR DESCRIPTION
Would solve part of #12 memory feeds from ER (works with my ER-6P) and corrections to #13 that I closed.

* Update zbx_edgemax_template.xml
  * Imported and exported to Zabbix 6.0
  * Replaced linked template with "Generic by SNMP"
  * Renamed Template to align with Zabbix's naming

* Update zbx_edgemax_template.xml
  * Replaced SNMP variable with their OID beacause `UCD-SNMP-MIB::memAvailReal` & `UCD-SNMP-MIB::memTotalReal` are not defined